### PR TITLE
feat: add github stargazers to header alert

### DIFF
--- a/components/ui/GithubStargazers.tsx
+++ b/components/ui/GithubStargazers.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "preact/hooks";
+
+export interface Props {
+  stargazers_count: number;
+}
+
+export const fetchRepo = async (repo: string): Promise<Props> => {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}`);
+    if (!response.ok) {
+      throw new Error("Erro ao buscar os dados do repositório");
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export interface GithubStargazesProps {
+  /** @title Github Stars */
+  /** @description example: add deco-cx/deco here */
+  repo?: string;
+}
+
+export default function GithubStargazes(
+  { repo }: GithubStargazesProps,
+) {
+  const [repoData, setRepoData] = useState<Props | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (repo) {
+      fetchRepo(repo)
+        .then((data) => {
+          setRepoData(data);
+        })
+        .catch((error) => {
+          console.error(error);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
+  }, [repo]);
+
+  return (
+    <>
+      {loading || !repoData ? null : (
+        <>
+          ⭐ {repoData.stargazers_count}
+        </>
+      )}
+    </>
+  );
+}

--- a/islands/Header.tsx
+++ b/islands/Header.tsx
@@ -5,9 +5,13 @@ import { useSignal } from "@preact/signals";
 import { useState } from "preact/hooks";
 import { useId } from "deco-sites/starting/sdk/useId.ts";
 import { Dropdown } from "deco-sites/starting/components/ui/Dropdown.tsx";
+import GithubStargazes, {
+  GithubStargazesProps,
+} from "deco-sites/starting/components/ui/GithubStargazers.tsx";
 
 export interface Alert {
-  label: string;
+  github?: GithubStargazesProps;
+  text: string;
 }
 
 export interface MenuLink {
@@ -200,16 +204,17 @@ export default function Header(props: Props) {
       {alerts?.mobile && alerts?.mobile.length > 0 && (
         <div id={idMobile} class="lg:hidden">
           <Slider class="carousel carousel-center w-screen bg-black text-white font-normal text-sm py-3">
-            {alerts.mobile.map((alert, index) => (
+            {alerts.mobile.map((alert, index) => [
               <Slider.Item index={index} class="carousel-item">
+                {alert.github && <GithubStargazes {...alert.github} />}
                 <span
-                  class="flex justify-center items-center w-screen"
+                  class="flex justify-center items-center w-screen gap-2"
                   dangerouslySetInnerHTML={{
-                    __html: alert.label,
+                    __html: alert.text,
                   }}
                 />
               </Slider.Item>
-            ))}
+            ])}
           </Slider>
           <SliderJS rootId={idMobile} interval={5 * 1e3} />
         </div>
@@ -219,12 +224,10 @@ export default function Header(props: Props) {
           <Slider class="carousel carousel-center w-screen bg-black text-white font-normal text-sm py-3">
             {alerts.desktop.map((alert, index) => (
               <Slider.Item index={index} class="carousel-item">
-                <span
-                  class="flex justify-center items-center w-screen"
-                  dangerouslySetInnerHTML={{
-                    __html: alert.label,
-                  }}
-                />
+                <span class="flex justify-center items-center w-screen gap-2">
+                  {alert.github && <GithubStargazes {...alert.github} />}
+                  <span dangerouslySetInnerHTML={{ __html: alert.text }} />
+                </span>
               </Slider.Item>
             ))}
           </Slider>

--- a/sections/Header.tsx
+++ b/sections/Header.tsx
@@ -1,16 +1,11 @@
 import HeaderIsland, { MenuLink } from "deco-sites/starting/islands/Header.tsx";
-
-export interface GitHub {
-  /** @format html */
-  mobile?: string;
-  /** @format html */
-  desktop?: string;
-}
+import { GithubStargazesProps } from "deco-sites/starting/components/ui/GithubStargazers.tsx";
 
 export interface Alert {
+  github?: GithubStargazesProps;
   /** @format html */
   /** @title Text */
-  label: string;
+  text: string;
 }
 
 export interface Alerts {
@@ -19,7 +14,6 @@ export interface Alerts {
 }
 
 export interface Props {
-  githubBarText?: GitHub;
   alerts?: Alerts;
   menuLinks: MenuLink[];
   idiom: string;


### PR DESCRIPTION
- Adding the dynamic display of stars from the github repository in the header alert, currently this is done manually, so this pr adds the possibility of displaying stars without the need for manual adjustments to the total amount