### PR TITLE
re-add copy snippets script + change gfm.css route and cache control headers

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -11,7 +11,7 @@ import * as $api_leads from "./routes/api/leads.tsx";
 import * as $api_platform from "./routes/api/platform.tsx";
 import * as $api_ranking from "./routes/api/ranking.ts";
 import * as $api_webinar from "./routes/api/webinar.tsx";
-import * as $gfm_css from "./routes/gfm.css.ts";
+import * as $docs_css from "./routes/docs.css.ts";
 import * as $hackathon4 from "./routes/hackathon4.ts";
 import * as $proxy_image_index from "./routes/proxy/image/index.tsx";
 import * as $Article from "./islands/Article.tsx";
@@ -65,7 +65,7 @@ const manifest = {
     "./routes/api/platform.tsx": $api_platform,
     "./routes/api/ranking.ts": $api_ranking,
     "./routes/api/webinar.tsx": $api_webinar,
-    "./routes/gfm.css.ts": $gfm_css,
+    "./routes/docs.css.ts": $docs_css,
     "./routes/hackathon4.ts": $hackathon4,
     "./routes/proxy/image/index.tsx": $proxy_image_index,
   },

--- a/routes/docs.css.ts
+++ b/routes/docs.css.ts
@@ -80,7 +80,7 @@ export const handler: Handlers = {
     return new Response(CSS, {
       headers: {
         "content-type": "text/css",
-        "cache-control": "public, max-age=31536000, immutable",
+        "cache-control": "public, max-age=86400, immutable",
       },
     });
   },

--- a/sections/CustomizableContent.tsx
+++ b/sections/CustomizableContent.tsx
@@ -42,7 +42,7 @@ export default function CustomizableMarkdownContent(
   return (
     <>
       <Head>
-        <link rel="stylesheet" href={`/gfm.css`} />
+        <link rel="stylesheet" href={`/docs.css`} />
         <style
           dangerouslySetInnerHTML={{
             __html: `

--- a/sections/MarkdownContent.tsx
+++ b/sections/MarkdownContent.tsx
@@ -34,7 +34,7 @@ export default function DocsPage(
             ? `${props.data.title} | deco.cx docs`
             : "deco.cx docs"}
         </title>
-        <link rel="stylesheet" href={`/gfm.css`} />
+        <link rel="stylesheet" href={`/docs.css`} />
         {description && <meta name="description" content={description} />}
         <style
           dangerouslySetInnerHTML={{

--- a/static/docs/js/copy-snippets.js
+++ b/static/docs/js/copy-snippets.js
@@ -1,0 +1,28 @@
+const div = document.createElement('div');
+
+const copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7m0 2.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667z" /><path d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1" /></svg>`;
+const okIcon = `<svg xmlns="http://www.w3.org/2000/svg"  width="16"  height="16"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l5 5l10 -10" /></svg>`;
+const copyElement = `<div class="tooltip-copy">${copyIcon}</div>`;
+const okElement = `<div class="tooltip-copy">${okIcon}</div>`;
+
+div.innerHTML = copyElement; 
+div.className = 'div-copy'; 
+
+const allPres = document.querySelectorAll('pre'); 
+allPres.forEach(function(pre) { 
+    let timeout = null;
+    const copy = div.cloneNode(true); 
+    pre.appendChild(copy);
+    pre.onmouseleave = function() { 
+        clearTimeout(timeout); 
+        copy.innerHTML = copyElement;
+    }; 
+    copy.onclick = function() { 
+        navigator.clipboard.writeText(pre.textContent);
+        copy.innerHTML = okElement;
+        clearTimeout(timeout);
+        timeout = setTimeout(function() {
+            copy.innerHTML = copyElement;
+        }, 3000); 
+    }; 
+}); 


### PR DESCRIPTION
Change gfm.css route and be less agressive with caching.

Ensures #319 is working by re-adding the copy snippets script that was deleted.