### PR TITLE
fix: first item of breadcrumb should not have href, it is always a category or the current page.

### DIFF
--- a/components/decohelp/pages/ui/BreadCrumb/Breadcrumb.tsx
+++ b/components/decohelp/pages/ui/BreadCrumb/Breadcrumb.tsx
@@ -19,7 +19,7 @@ function Breadcrumb({
         {items.map(({ name, href }, index) => (
           <li class="flex items-center gap-2" key={index}>
             <a
-              href={href}
+              href={index === 0 ? "#" : href}
               class={`${index === items.length - 1 ? "text-[#4ADE80]" : "text-white"} 
               text-[15px] font-normal leading-tight capitalize`}
             >


### PR DESCRIPTION
fix: first item of breadcrumb should not link, it is always a category or the current page.