### PR TITLE
Fix: The feedback button doesn't seem to do anything

### DIFF
--- a/components/decohelp/pages/ui/WasThisPageHelpful/WasThisPageHelpful.tsx
+++ b/components/decohelp/pages/ui/WasThisPageHelpful/WasThisPageHelpful.tsx
@@ -14,7 +14,7 @@ export interface WasThisPageHelpfulProps {
       PositiveIcon?: ImageWidget;
       Width?: number;
       Height?: number;
-    };
+    }; 
 
     Text?: HTMLWidget;
   };
@@ -50,6 +50,12 @@ export default function WasThisPageHelpfulContent({
       contents: [helpful, label, window.location.href],
     });
     setIsPending(false);
+
+    const toast = document.getElementById('feedback-toast');
+    toast.classList.remove('hidden');
+    setTimeout(() => {
+      toast.classList.add('hidden');
+    }, 3000); // Hide after 3 seconds
   };
 
   const buttonProps = WasThisPageHelpful?.Button;
@@ -117,6 +123,11 @@ export default function WasThisPageHelpfulContent({
             class="text-[#FFFFFF80] text-[0.875rem] leading-[1.125rem] tracking-[-0.14px]"
             dangerouslySetInnerHTML={{ __html: text }}
           />
+          <div id="feedback-toast" className="toast hidden transition duration-700">
+            <div className="alert text-sm">
+              <span>Thank you for your feedback!</span>
+            </div>
+          </div>
         </div>
       )}
     </>


### PR DESCRIPTION
Turns out, it was doing something. The user just wasn't receiving confirmation that their feedback was sent.

Fix: add a toast with a message "Thank you for your feedback!"