### PR TITLE
Adding the topic Setting up GA4 for A/B testing to the How do I create and track an A/B test? section

### DIFF
--- a/docs/developing-capabilities/apps/ab-test/en.md
+++ b/docs/developing-capabilities/apps/ab-test/en.md
@@ -14,6 +14,7 @@ Let's explore each step:
 - Editing your variant
 - Creating events and collecting data
 - Funnel and results
+- GA4 Setup for A/B Testing
 
 ## Creating an Experiment
 
@@ -121,7 +122,7 @@ Data is transferred in real-time, no more waiting a day or two to analyze them.
 
 ## GA4 Setup for A/B Testing
 
-To ensure that customers consistently see the same version when browsing an A/B Test on deco.cx, we use a cookie called _deco_segment_.
+To ensure data consistency while navigating an A/B test on deco.cx, we use a cookie called deco_segment.
 
 This cookie lasts for 30 days by default and can be used to determine which version the user is in.
 
@@ -150,4 +151,4 @@ getData(myCookie) {
 }
 ```
 
-In this way, within GTM you can know whether the user is part of Test X or not and send the events in a segmented manner.
+This way, in GTM, you can identify whether the user is participating in Test X, allowing for the segmented and accurate dispatch of events.

--- a/docs/developing-capabilities/apps/ab-test/en.md
+++ b/docs/developing-capabilities/apps/ab-test/en.md
@@ -118,3 +118,36 @@ Data is transferred in real-time, no more waiting a day or two to analyze them.
 ![Experiments screen](https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/530/6ddc740d-9590-431b-b1e7-f0a0130bc5f6)
 
 ![Experiments screen](https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/530/cc637298-e938-494c-9253-b7d1bef6f99a)
+
+## GA4 Setup for A/B Testing
+
+To ensure that customers consistently see the same version when browsing an A/B Test on deco.cx, we use a cookie called _deco_segment_.
+
+This cookie lasts for 30 days by default and can be used to determine which version the user is in.
+
+All data sent to the deco.cx Analytics is already segmented by version.
+
+However, for this to also occur in GA4, it is necessary to check this cookie and segment the events based on that information.
+
+ - Example of cookie:
+```
+deco_segment=TdCJTIyYWN0aXZlJTIyJTNBJTVCJTVEJTJDJTIyaW5hY3RpdmVEcmF3biUyMiUzQSU1QiUyMlRlc3RlJTIwVGF2YW5vJTIyJTVEJTdE
+```
+
+ - To extract readable data from this hash, use the following function:
+```javascript
+getData(myCookie) {
+	return JSON.parse(decodeURIComponent(atob(myCookie)))
+}
+
+```
+
+ - This will return an object like:
+```json
+{
+	active: [],
+	inactiveDrawn: ['Teste Tavano']
+}
+```
+
+In this way, within GTM you can know whether the user is part of Test X or not and send the events in a segmented manner.

--- a/docs/developing-capabilities/apps/ab-test/pt.md
+++ b/docs/developing-capabilities/apps/ab-test/pt.md
@@ -124,3 +124,35 @@ analisá-los.
 ![Experiments screen](https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/530/6ddc740d-9590-431b-b1e7-f0a0130bc5f6)
 
 ![Experiments screen](https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/530/cc637298-e938-494c-9253-b7d1bef6f99a)
+
+## Setup do GA4 para Teste A/B
+
+Para garantir que os clientes vejam sempre na mesma versão ao navegar em um Teste A/B na deco.cx, utilizamos um cookie, chamado _deco_segment_.
+
+Esse cookie dura por padrão 30 dias e pode ser utilizado para entender em qual versão o usuário está.
+
+Todos os dados que vão para o Analytics da deco.cx, já são separados por segmento.
+
+Porém, para que isso também aconteça no GA4, é necessário verificar esse cookie e segmentar os eventos com base nessa informação.
+
+ - Exemplo de cookie
+```
+deco_segment=TdCJTIyYWN0aXZlJTIyJTNBJTVCJTVEJTJDJTIyaW5hY3RpdmVEcmF3biUyMiUzQSU1QiUyMlRlc3RlJTIwVGF2YW5vJTIyJTVEJTdE
+```
+
+ - Para extrair o dado legível deste hash, utilize a função:
+```javascript
+getData(myCookie) {
+	return JSON.parse(decodeURIComponent(atob(myCookie)))
+}
+```
+
+ - Isso irá devolver um objeto como:
+```json
+{
+	active: [],
+	inactiveDrawn: ['Teste Tavano']
+}
+```
+
+Desta forma, no GTM você tem a informação se o usuário está ou não no Teste X e pode enviar os eventos de forma segmentada.

--- a/docs/developing-capabilities/apps/ab-test/pt.md
+++ b/docs/developing-capabilities/apps/ab-test/pt.md
@@ -127,7 +127,7 @@ analisá-los.
 
 ## Setup do GA4 para Teste A/B
 
-Para garantir que os clientes vejam sempre na mesma versão ao navegar em um Teste A/B na deco.cx, utilizamos um cookie, chamado _deco_segment_.
+Para assegurar a consistência dos dados fornecidos fornecidos ao navegar em um Teste A/B na deco.cx, utilizamos um cookie, chamado _deco_segment_.
 
 Esse cookie dura por padrão 30 dias e pode ser utilizado para entender em qual versão o usuário está.
 
@@ -155,4 +155,4 @@ getData(myCookie) {
 }
 ```
 
-Desta forma, no GTM você tem a informação se o usuário está ou não no Teste X e pode enviar os eventos de forma segmentada.
+Dessa forma, no GTM, você consegue identificar se o usuário está participando do Teste X, permitindo o envio de eventos de forma segmentada e precisa.


### PR DESCRIPTION
 - Adding the topic Setting up GA4 for A/B testing to the How do I create and track an A/B test? section on the documentation pages